### PR TITLE
Fix HOPO calculations in AutoGH

### DIFF
--- a/RhythmGames.xml
+++ b/RhythmGames.xml
@@ -15,6 +15,9 @@
     <Truncation>100</Truncation>
     <MinimumDuration>50</MinimumDuration>
     <DrumNotes>02134</DrumNotes>
+    <Hopo>
+      <Song Title="_Default">170</Song>
+    </Hopo>
   </Game>
   <Game Name="Guitar Hero II" Code="GH2">
     <Strum />
@@ -44,33 +47,95 @@
     <MinimumDuration>25</MinimumDuration>
   </Game>
   <Game Name="Rock Band" Code="RB">
+    <LoadTime>3500</LoadTime>
     <DrumNotes>41230</DrumNotes>
+    <Hopo>
+      <Song Title="_Default">170</Song>
+      <Song Title="areyougonnabemygirl">250</Song>
+      <Song Title="ballroomblitz">250</Song>
+      <Song Title="blackholesun">95</Song>
+      <Song Title="brainpower">250</Song>
+      <Song Title="daylatedollarshort">250</Song>
+      <Song Title="deadonarrival">250</Song>
+      <Song Title="gowiththeflow">250</Song>
+      <Song Title="greengrass">250</Song>
+      <Song Title="highwaystar">250</Song>
+      <Song Title="igetby">250</Song>
+      <Song Title="imsosick">92</Song>
+      <Song Title="paranoid">250</Song>
+      <Song Title="welcomehome">95</Song>
+      <Song Title="alabamagetaway">250</Song>
+      <Song Title="bodhisattva">250</Song>
+      <Song Title="ramblinman">250</Song>
+      <Song Title="action">250</Song>
+    </Hopo>
   </Game>
-  <Game Name="Rock Band II" Code="RB2" />
-  <Game Name="Rock Band: Beatles" Code="RBB" />
+  <Game Name="Rock Band II" Code="RB2">
+    <DrumNotes>41230</DrumNotes>
+    <Hopo>
+      <Song Title="_Default">170</Song>
+    </Hopo>
+  </Game>
+  <Game Name="Rock Band: Beatles" Code="RBB">
+    <DrumNotes>41230</DrumNotes>
+    <Hopo>
+      <Song Title="_Default">170</Song>
+      <Song Title="somebodytolove">90</Song>
+    </Hopo>
+  </Game>
   <Game Name="Lego Rock Band" Code="LRB">
+    <DrumNotes>41230</DrumNotes>
     <MinimumDuration>35</MinimumDuration>
+    <Hopo>
+      <Song Title="_Default">170</Song>
+      <Song Title="dig">90</Song>
+      <Song Title="dreamingofyou">250</Song>
+      <Song Title="thunder">90</Song>
+      <Song Title="valerie">90</Song>
+      <Song Title="wearethechampions">90</Song>
+    </Hopo>
   </Game>
   <Game Name="RB Pack: Country 1" Code="RBTP_CTY1">
     <DrumNotes>41230</DrumNotes>
+    <Hopo>
+      <Song Title="_Default">170</Song>
+    </Hopo>
   </Game>
   <Game Name="RB Pack: Country 2" Code="RBTP_CTY2">
     <DrumNotes>41230</DrumNotes>
+    <Hopo>
+      <Song Title="_Default">170</Song>
+    </Hopo>
   </Game>
   <Game Name="RB Pack: AC/DC" Code="RBTP_ACDC">
     <DrumNotes>41230</DrumNotes>
+    <Hopo>
+      <Song Title="_Default">170</Song>
+    </Hopo>
   </Game>
   <Game Name="RB Pack: Classic Rock" Code="RBTP_CR">
     <DrumNotes>41230</DrumNotes>
+    <Hopo>
+      <Song Title="_Default">170</Song>
+    </Hopo>
   </Game>
   <Game Name="RB Pack: Metal" Code="RBTP_MTL">
     <DrumNotes>41230</DrumNotes>
+    <Hopo>
+      <Song Title="_Default">170</Song>
+    </Hopo>
   </Game>
   <Game Name="RB Pack: Pack 2" Code="RBTP_PK2">
     <DrumNotes>41230</DrumNotes>
+    <Hopo>
+      <Song Title="_Default">170</Song>
+    </Hopo>
   </Game>
   <Game Name="Rock Band: Green Day" Code="RBGD">
     <DrumNotes>41230</DrumNotes>
     <MinimumDuration>25</MinimumDuration>
+    <Hopo>
+      <Song Title="_Default">170</Song>
+    </Hopo>
   </Game>
 </Games>

--- a/clsElements.vb
+++ b/clsElements.vb
@@ -160,6 +160,7 @@ End Enum
 Friend Class clsSong
     Friend _game As clsRhythmGame
     Friend name As String
+    Friend title As String
     Friend fi As IO.FileInfo
     Private _mf As NAudio.Midi.MidiFile
     Private _startTime As Date
@@ -174,6 +175,9 @@ Friend Class clsSong
     Friend Sub New(newFI As IO.FileInfo, game As clsRhythmGame)
         fi = newFI
         name = IO.Path.GetFileNameWithoutExtension(fi.FullName)
+        ' Only Rock Band MIDIs have song titles which will get loaded when the track list is parsed
+        ' Provide a suitable default for Guitar Hero songs
+        title = name
         _game = game
     End Sub
 

--- a/clsRhythmGame.vb
+++ b/clsRhythmGame.vb
@@ -10,6 +10,7 @@
     Public loadTime As Integer
     Public truncation As Integer
     Public minimumDuration As Integer
+    Public hopoTrigger As Dictionary(Of String, Integer)
 
     Public Sub New(bn As Xml.XmlNode, base As clsRhythmGame)
         Dim n As Xml.XmlNode
@@ -38,6 +39,19 @@
         For i As Integer = 0 To 4
             drumNotes(i) = notes(CInt(drumNoteStr.Substring(i, 1)))
         Next
+
+        n = bn.SelectSingleNode("Hopo")
+        If n IsNot Nothing Then
+            hopoTrigger = New Dictionary(Of String, Integer)
+            Dim nodeList As Xml.XmlNodeList
+            nodeList = n.SelectNodes("*")
+            For Each node As Xml.XmlNode In n.SelectNodes("Song")
+                hopoTrigger(node.Attributes("Title").Value) = CInt(node.InnerText)
+            Next
+        Else
+            ' Nothing indicates the Guitar Hero default of a 1/12th node
+            hopoTrigger = Nothing
+        End If
     End Sub
 
     Private Function getBtnValue(name As String) As Integer

--- a/frmEdit.vb
+++ b/frmEdit.vb
@@ -1238,7 +1238,7 @@ Public Class frmEdit
             Next
             refreshGroup()
             Dim sb As New System.Text.StringBuilder
-            sb.AppendLine("Song: " & ss.cbSong.SelectedItem.ToString() & " (" & ss.cbGame.SelectedItem.ToString() & ")" & IIf(ss.info <> vbNullString, " - #" & ss.info, ""))
+            sb.AppendLine("Song: " & CType(ss.cbSong.SelectedItem, clsSong).title & " (" & ss.cbGame.SelectedItem.ToString() & ")" & IIf(ss.info <> vbNullString, " - #" & ss.info, ""))
             Dim players As New List(Of String)
             If Not ss.cbTrack0.SelectedItem Is Nothing Then players.Add("#1 " & ss.cbTrack0.SelectedItem.ToString() & " [" & ss.cbLevel0.SelectedItem.ToString() & "]")
             If Not ss.cbTrack1.SelectedItem Is Nothing Then players.Add("#2 " & ss.cbTrack1.SelectedItem.ToString() & " [" & ss.cbLevel1.SelectedItem.ToString() & "]")

--- a/frmMusic.vb
+++ b/frmMusic.vb
@@ -242,6 +242,9 @@ Public Class frmMusic
                                 Dim track As New clsTrack(song.mf, i, match.Groups("part").Value, song)
                                 lstTracks.Add(track)
                                 cb.Items.Add(track)
+                            ElseIf i = 0 Then
+                                ' The track title for track 0 is the title of the song
+                                song.title = name
                             End If
                             Exit For
                         End If
@@ -329,11 +332,19 @@ Public Class frmMusic
                         trackCount += 1
                     Case Else
                         If (Not cbLevel(i).SelectedItem Is Nothing) Then
-                            Dim trackNotes As List(Of clsNoteEntry) = getNotes(i + 1, cbTrack(i).SelectedItem, cbLevel(i).SelectedItem)
+                            Dim hopoThreshold As Integer
+                            With CType(cbGame.SelectedItem, clsRhythmGame)
+                                If .hopoTrigger Is Nothing Then
+                                    hopoThreshold = CType(cbTrack(i).SelectedItem, clsTrack)._song.mf.DeltaTicksPerQuarterNote / 3
+                                ElseIf Not .hopoTrigger.TryGetValue(CType(cbSong.SelectedItem, clsSong).title, hopoThreshold) Then
+                                    hopoThreshold = CType(cbGame.SelectedItem, clsRhythmGame).hopoTrigger("_Default")
+                                End If
+                            End With
+                            Dim trackNotes As List(Of clsNoteEntry) = getNotes(i + 1, cbTrack(i).SelectedItem, cbLevel(i).SelectedItem, hopoThreshold)
                             If trackNotes Is Nothing Then Exit Sub
-                            allNotes.AddRange(trackNotes)
-                            trackCount += 1
-                        End If
+                                allNotes.AddRange(trackNotes)
+                                trackCount += 1
+                            End If
                 End Select
             End If
         Next

--- a/modMusicConverter.vb
+++ b/modMusicConverter.vb
@@ -1,4 +1,5 @@
-﻿Imports NAudio
+﻿Imports System.Linq
+Imports NAudio
 'https://github.com/TheBoxyBear/ChartTools/blob/stable/docs/FileFormats/midi.md
 Friend Class clsNoteAction
     Implements IComparable(Of clsNoteAction)
@@ -395,7 +396,7 @@ Module modMusicConverter
     End Sub
 
 
-    Public Function getNotes(controller As Byte, Track As clsTrack, Level As clsLevel) As List(Of clsNoteEntry)
+    Public Function getNotes(controller As Byte, Track As clsTrack, Level As clsLevel, HopoThreshold As Integer) As List(Of clsNoteEntry)
         Dim baseNote As Integer = Level.baseNote
         Dim mf As Midi.MidiFile = Track.mf
         Dim tempos As New List(Of clsTempoEntry)
@@ -522,9 +523,11 @@ Module modMusicConverter
                     If checkQ(nevTime, forceHOPOQ) Then
                         doHopo = True
                     Else
-                        If nevTime - lastGroup(0).Item2.AbsoluteTime <= mf.DeltaTicksPerQuarterNote / 3 Then
-                            If lastGroup.Count = 1 AndAlso nevGroup.Count = 1 AndAlso lastGroup(0).Item2.NoteNumber <> nevGroup(0).Item2.NoteNumber Then
-                                doHopo = True
+                        If nevTime - lastGroup(0).Item2.AbsoluteTime <= HopoThreshold Then
+                            If nevGroup.Count = 1 Then
+                                If Not lastGroup.Select(Function(x) x.Item2.NoteNumber).Contains(nevGroup(0).Item2.NoteNumber) Then
+                                    doHopo = True
+                                End If
                             End If
                         End If
                     End If


### PR DESCRIPTION
There were two errors in the HOPO calcuation made in AutoGH.

The first is that the code assumed that both a HOPO and the note that
preceded it cannot be chords.  That is incorrect: While the HOPO'ed
note cannot be a chord, the preceding note can be a chord as long as
it doesn't contain the HOPO'ed note.

Second, the time threshold for whether a note can be a HOPO or not
is incorrect for RockBand games.

In RockBand games, the time threshold for considering whether a note
is a HOPO can vary. By default, it is 170 ticks but it can be more or
less.  This data is recorded in a config file in the game but is not
stored in the MIDI file.

This change allows the threshold for games and an override for
individual songs to be stored in RhythmGames.xml. The songs are indexed
by title, which is stored as the name of track 0 in RockBand tracks.

If not specified, it continues to use the old formula of a 12th note
(which seems to correspond to 160 for most songs).

This was tested with Black Hole Sun (on Rock Band) and by getting the
100% with HOPO achievement in Beatles Rock Band.

Information on HOPO thresholds came from
https://github.com/ajanata/rock-band-chart-generator

The songs added to the config are only the songs I can validate (the
on-disk Rock Band, Lego Rock Band, and Rock Band Beatles).

This was validated by playing through all three Beatles Rock Band songs
with achievements for 100% HOPO as well as playing through Black Hole
Sun (in Rock Band) which is one of the songs with a non-standard
threshold that failed badly with the previous settings.