### PR TITLE
Handle vocal generation errors more gracefully

### DIFF
--- a/frmMusic.vb
+++ b/frmMusic.vb
@@ -6,6 +6,7 @@
 'ability to pause,stop,start from a certain line
 
 Imports System.IO
+Imports System.Linq
 
 Public Class frmMusic
 
@@ -622,8 +623,17 @@ Public Class frmMusic
 
     Private Sub Button1_Click(sender As System.Object, e As System.EventArgs) Handles btnMakeVocals.Click
         Dim rg As clsRhythmGame = CType(cbGame.SelectedItem, clsRhythmGame)
+        Dim errors As List(Of String) = New List(Of String)
         For Each fi As IO.FileInfo In New IO.DirectoryInfo(basepath & rg.code).GetFiles("*.mid")
-            If Not IO.File.Exists(fi.FullName.Substring(0, fi.FullName.Length - 4) & ".mp3") Then modVocal.generateMP3(fi.FullName)
+            Try
+                If Not IO.File.Exists(fi.FullName.Substring(0, fi.FullName.Length - 4) & ".mp3") Then modVocal.generateMP3(fi.FullName)
+            Catch ex As Exception
+                errors.Add(fi.Name)
+            End Try
         Next
+
+        If errors.Any() Then
+            MsgBox("Some error(s) occured whilst generating mp3's for the following:" & vbCrLf & vbCrLf & String.Join("," & vbCrLf, errors.ToArray()))
+        End If
     End Sub
 End Class

--- a/modVocal.vb
+++ b/modVocal.vb
@@ -348,16 +348,26 @@ Module modVocal
                 End If
             End If
         Next
-        Clipboard.SetText(tb.ToString)
 
-        vocalTrack.readnotes(mf, tempos)
-        beatTrack.readnotes(mf, tempos)
-        Dim files As New List(Of IO.FileInfo)
+        If tb.Length > 0 Then
+            Clipboard.SetText(tb.ToString)
+        End If
+
         Dim filename As String = vbNullString
-        vocalTrack.generateSamples(vocalTrack.startTime, vocalTrack.endTime)
-        filename = midipath.Substring(0, InStrRev(midipath, ".") - 1) & ".wav"
-        saveWav(vocalTrack.samples.ToArray(), filename)
-        offset = vocalTrack.startTime
+        If vocalTrack IsNot Nothing Then
+            vocalTrack.readnotes(mf, tempos)
+            vocalTrack.generateSamples(vocalTrack.startTime, vocalTrack.endTime)
+            filename = midipath.Substring(0, InStrRev(midipath, ".") - 1) & ".wav"
+            saveWav(vocalTrack.samples.ToArray(), filename)
+        End If
+
+        If beatTrack IsNot Nothing Then
+            beatTrack.readnotes(mf, tempos)
+            beatTrack.generateSamples(beatTrack.startTime, beatTrack.endTime)
+            filename = midipath.Substring(0, InStrRev(midipath, ".") - 1) & ".wav"
+            saveWav(beatTrack.samples.ToArray(), filename)
+        End If
+
         Return New IO.FileInfo(filename)
     End Function
 


### PR DESCRIPTION
Currently whenever I run "Make Vocals" I'm greeted with this error:

![image](https://github.com/palesius/AutoGH/assets/10059155/3a4afa1d-a338-4e87-ae95-f043ba3d1cce)

After some debugging it turns out that its because of this line `Clipboard.SetText(tb.ToString)` , I'm not sure what is expected here as the GHWT song's i've been using have never hit the breakpoint inside the if..

After wrapping in a If, I was met with another error where vocaltrack would be nothing and beattrack would have a value so I have split these out to work independently of one another

In some cases I was hitting an error where there is no vocals (the guitar battles for example), so there would be another error thrown - this is now caught and handled with some info rather than a callstack.

![image](https://github.com/palesius/AutoGH/assets/10059155/724e935f-f26d-449b-af00-c50d3785c20f)
