### PR TITLE
Adds support for Expert+ On GH

### DIFF
--- a/RhythmGames.xml
+++ b/RhythmGames.xml
@@ -73,6 +73,20 @@
     </Notes>
     <Dilation>1.00008</Dilation>
   </Game>
+  <Game Name="Guitar Hero: Van Halen" Code="GHVH">
+    <Strum>DOWN</Strum>
+    <SoloStrum>DOWN</SoloStrum>
+    <DrumNotes>4123304</DrumNotes>
+    <Notes>
+      <Green>A</Green>
+      <Red>B</Red>
+      <Blue>X</Blue>
+      <Yellow>Y</Yellow>
+      <Orange>LB</Orange>
+    </Notes>
+    <Dilation>1.00008</Dilation>
+    <MinimumDuration>20</MinimumDuration>
+  </Game>
   <Game Name="Rock Band" Code="RB">
     <LoadTime>3500</LoadTime>
     <DrumNotes>41230</DrumNotes>

--- a/clsElements.vb
+++ b/clsElements.vb
@@ -12,6 +12,7 @@ Enum enumLevel
     lvlMedium = 1
     lvlHard = 2
     lvlExpert = 3
+    lvlExpertPlus = 4
 End Enum
 
 'Friend Class clsGame
@@ -244,11 +245,13 @@ Friend Class clsTrack
         End Get
     End Property
 
-    Friend ReadOnly Property noteGreen(Optional nostrum As Boolean = False, Optional solo As Boolean = False, Optional fifthLane As Boolean = False) As Integer
+    Friend ReadOnly Property noteGreen(Optional nostrum As Boolean = False, Optional solo As Boolean = False, Optional fifthLane As Boolean = False, Optional sixthLane As Boolean = False) As Integer
         Get
             Select Case name
                 Case "DRUMS"
-                    If fifthLane Then
+                    If sixthLane Then
+                        Return _game.drumNotes(6) + IIf(nostrum, 0, strumButton(solo))
+                    ElseIf fifthLane Then
                         Return _game.drumNotes(5) + IIf(nostrum, 0, strumButton(solo))
                     Else
                         Return _game.drumNotes(0) + IIf(nostrum, 0, strumButton(solo))
@@ -351,6 +354,8 @@ Friend Class clsLevel
                     Return 84
                 Case enumLevel.lvlExpert
                     Return 96
+                Case enumLevel.lvlExpertPlus
+                    Return 95
                 Case Else
                     Return -1
             End Select
@@ -371,6 +376,34 @@ Friend Class clsLevel
                         Return 5
                     Case enumLevel.lvlExpert
                         Return 5
+                    Case enumLevel.lvlExpertPlus
+                        Return 6
+                    Case Else
+                        Return -1
+                End Select
+            End If
+        End Get
+    End Property
+
+    Friend ReadOnly Property noteValue(track As String, noteNumber As Integer) As Integer
+        Get
+            If track <> "DRUMS" Then
+                Return noteNumber - baseNote
+            Else
+                Select Case index
+                    Case enumLevel.lvlEasy
+                    Case enumLevel.lvlMedium
+                    Case enumLevel.lvlHard
+                    Case enumLevel.lvlExpert
+                        Return noteNumber - baseNote
+                    Case enumLevel.lvlExpertPlus
+                        Dim value = (noteNumber - baseNote) - 1
+
+                        If value = -1 Then
+                            Return 6
+                        End If
+
+                        Return value
                     Case Else
                         Return -1
                 End Select
@@ -388,6 +421,8 @@ Friend Class clsLevel
                 Return "Hard"
             Case enumLevel.lvlExpert
                 Return "Expert"
+            Case enumLevel.lvlExpertPlus
+                Return "Expert+"
             Case Else
                 Return vbNullString
         End Select

--- a/clsRhythmGame.vb
+++ b/clsRhythmGame.vb
@@ -3,7 +3,7 @@
     Public code As String
     Public notes(4) As Integer
     Public drumNoteStr As String
-    Public drumNotes(5) As Integer
+    Public drumNotes(6) As Integer
     Public strum As Integer
     Public soloStrum As Integer
     Public dilation As Decimal
@@ -36,7 +36,7 @@
         If n Is Nothing Then minimumDuration = base.minimumDuration Else minimumDuration = CInt(n.InnerText)
         n = bn.SelectSingleNode("DrumNotes")
         If n Is Nothing Then drumNoteStr = base.drumNoteStr Else drumNoteStr = n.InnerText
-        For i As Integer = 0 To 5
+        For i As Integer = 0 To 6
             If i >= drumNoteStr.Length Then
                 Exit For
             End If

--- a/frmMusic.vb
+++ b/frmMusic.vb
@@ -15,7 +15,7 @@ Public Class frmMusic
     Private dictGames As SortedDictionary(Of String, clsRhythmGame)
     Private lstSongs As New List(Of clsSong)
     Private lstTracks As New List(Of clsTrack)
-    Private arrLevel(3) As clsLevel
+    Private arrLevel(4) As clsLevel
 
     Private lastGame As clsRhythmGame
     Private lastSong As clsSong
@@ -117,7 +117,7 @@ Public Class frmMusic
 
         loadGames()
 
-        For i As Integer = 0 To 3
+        For i As Integer = 0 To 4
             arrLevel(i) = New clsLevel(i)
         Next i
 

--- a/modMusicConverter.vb
+++ b/modMusicConverter.vb
@@ -4,13 +4,11 @@ Imports NAudio
 
 Public Class clsNoteInfo
     Public noteNumber As Integer
-    Public baseNote As Integer
     Public noteValue As Integer
 
-    Public Sub New(_noteNumber As Integer, _baseNote As Integer)
+    Public Sub New(_noteNumber As Integer, _noteValue As Integer)
         noteNumber = _noteNumber
-        baseNote = _baseNote
-        noteValue = _noteNumber - _baseNote
+        noteValue = _noteValue
     End Sub
 
     Public Overrides Function ToString() As String
@@ -114,7 +112,7 @@ Friend Class clsNoteEntry
 
     Public Sub New(_controller As String, _track As clsTrack, _level As clsLevel, _nev As Midi.NoteOnEvent, _solo As Boolean, _hopo As Boolean, _eventIndex As Integer, _section As String)
         controller = _controller
-        noteInfo = New clsNoteInfo(_nev.NoteNumber, _level.baseNote)
+        noteInfo = New clsNoteInfo(_nev.NoteNumber, _level.noteValue(_track.name, _nev.NoteNumber))
         tickOffset = _nev.AbsoluteTime
         tickDuration = _nev.NoteLength
         solo = _solo
@@ -138,6 +136,9 @@ Friend Class clsNoteEntry
             Case 5
                 noteMask = _track.noteGreen(hopo, solo, True)
                 ' Console.WriteLine(String.Format("{0} Green (Fifth): ({1} | {2} | NM: {3})", _eventIndex, noteInfo.ToString(), _section, noteMask.ToString()))
+            Case 6
+                noteMask = _track.noteGreen(hopo, solo, False, True)
+                ' Console.WriteLine(String.Format("{0} Green (Sixth): ({1} | {2} | NM: {3})", _eventIndex, noteInfo.ToString(), _section, noteMask.ToString()))
         End Select
         eventIndex = _eventIndex
         section = _section


### PR DESCRIPTION
Added Support for Expert+ On Guitar Hero Van Halen

![image](https://github.com/palesius/AutoGH/assets/10059155/42daffea-bd82-4cff-a78f-814527d10b22)

Because Expert+ starts at 95 to add this as the 6th note, had to determine the note value in clsLevel by checking if it has a value of -1 after minusing 1 to put the notes back to their original values.

Also fixed an issue with the loop where I observed that in some cases it could cause a thread to double up and do double the actions or not stop correctly.

Just want to say again, thank you for an amazing macro tool - I have thoroughly enjoyed being able to contribute some small additions to it.